### PR TITLE
Affected changes from the new UCSC Table Query interface of rtracklayer package

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -32,7 +32,7 @@ importClassesFrom(BiocIO, BiocFile, CompressedFile)
 
 importFrom(rtracklayer, FileForFormat, import, asBED, asGFF, browserSession,
                         ucscTableQuery, tableNames, getTable, trackNames,
-                        ucscSchema)
+                        ucscSchema, ucscTables)
 
 
 exportClasses(TxDb, FeatureDb)

--- a/R/makeFeatureDbFromUCSC.R
+++ b/R/makeFeatureDbFromUCSC.R
@@ -156,7 +156,8 @@ supportedUCSCFeatureDbTables <- function(genome, track)
 {
   session <- browserSession()
   genome(session) <- genome
-  query <- ucscTableQuery(session, track=track)
+  table <- ucscTables(genome, track)
+  query <- ucscTableQuery(session, table=table)
   if(checkTable(query)){
     tableNames(query)	
   }else{
@@ -182,9 +183,7 @@ UCSCFeatureDbTableSchema <- function(genome,
     stop("table \"", tablename, "\" is not supported")
   
   ## then make a query
-  query <- ucscTableQuery(session,
-                          track=track,
-                          table=tablename)  
+  query <- ucscTableQuery(session, table=tablename)
   res <- ucscSchema(query)
   ## now for the tricky part: converting from MYSQL to R...  There is no good
   ## way to extract the "R" type information from the data.frame since it
@@ -267,7 +266,7 @@ makeFeatureDbFromUCSC <- function(genome,
     ## Create a UCSC Genome Browser session.
     session <- browserSession(url=url)
     genome(session) <- genome
-    track_tables <- tableNames(ucscTableQuery(session, track=track))
+    track_tables <- ucscTables(genome, track)
     if (!(tablename %in% track_tables))
         stop("GenomicFeatures internal error: ", tablename, " table doesn't ",
              "exist or is not associated with ", track, " track. ",
@@ -277,7 +276,7 @@ makeFeatureDbFromUCSC <- function(genome,
     
     ## Download the data table.
     message("Download the ", tablename, " table ... ", appendLF=FALSE)
-    query <- ucscTableQuery(session, track, table=tablename)
+    query <- ucscTableQuery(session, table=tablename)
     ucsc_table <- getTable(query)
     
     ## check that we have strand info, and if not, add some in

--- a/R/makeFeatureDbFromUCSC.R
+++ b/R/makeFeatureDbFromUCSC.R
@@ -154,12 +154,9 @@ supportedUCSCFeatureDbTracks <- function(genome)
 ## Discover table names available in Tracks
 supportedUCSCFeatureDbTables <- function(genome, track)
 {
-  session <- browserSession()
-  genome(session) <- genome
-  table <- ucscTables(genome, track)
-  query <- ucscTableQuery(session, table=table)
-  if(checkTable(query)){
-    tableNames(query)	
+  tables <- ucscTables(genome, track)
+  if(length(tables)){
+    tables
   }else{
     stop("The track provided does not contain tables that are available in tabular form.")
   }

--- a/R/makeFeatureDbFromUCSC.R
+++ b/R/makeFeatureDbFromUCSC.R
@@ -131,8 +131,9 @@ checkTable <- function(query){
 
 ## helper to check a track
 isGoodTrack <- function(track, session){
-  query <- ucscTableQuery(session, track=track)
-  checkTable(query)
+  query <- ucscTableQuery(session)
+  tracks <- trackNames(query)
+  track %in% names(tracks)
 }
 
 ## helper to detect and generate a list of "legitimate" tracks

--- a/R/makeFeatureDbFromUCSC.R
+++ b/R/makeFeatureDbFromUCSC.R
@@ -126,7 +126,7 @@
 
 ## helper function to ID tables that rtracklayer won't process.
 checkTable <- function(query){
-  "primaryTable" %in% rtracklayer:::ucscTableOutputs(query)
+  query@table %in% rtracklayer:::tableNames(query)
 }
 
 ## helper to check a track


### PR DESCRIPTION
Hello @hpages 

GenomicFeatures package was affected in two places because of recent rtracklayer changes:
**1.** `checkTable()` which is fixed with https://github.com/Bioconductor/GenomicFeatures/commit/efd665c82b86a8f060627234f34b435a3858d445

**2.** `UCSCFeatureDbTableSchema()` uses `ucscSchema()` to get example data of a table then used to guess R type from the example data.
As `ucscSchema()` now utilizes UCSC REST API that does not provide any example data, but it provides a JSON type that might be helpful to generate a mapping between R types. That might be easy compared to the SQL type as the javascript type system is relatively simple compared to SQL.

**Example:**
```R
> library(rtracklayer)
> x <- ucscSchema(ucscTableQuery("hg38", table = "gold"))
> x[c("field", "JSON.type", "SQL.type")]

UCSCSchema table 'gold' with 45830 rows and 3 columns
DataFrame with 10 rows and 3 columns
         field   JSON.type         SQL.type
   <character> <character>      <character>
1          bin      number      smallint(6)
2        chrom      string     varchar(255)
3   chromStart      number int(10) unsigned
4     chromEnd      number int(10) unsigned
5           ix      number          int(11)
6         type      string          char(1)
7         frag      string     varchar(255)
8    fragStart      number int(10) unsigned
9      fragEnd      number int(10) unsigned
10      strand      string          char(1)
```

What are your thoughts about this approach?